### PR TITLE
Mouth size & facial line opacity

### DIFF
--- a/public/editor.html
+++ b/public/editor.html
@@ -90,15 +90,13 @@
       <div class="d-md-flex">
         <div class="flex-grow-1">
           <div class="mb-4 mt-2 d-xl-flex">
-            <h1>
-              faces.js editor
-            </h1>
+            <h1>faces.js editor</h1>
             <div class="d-sm-flex align-items-center ml-xl-3">
               <div class="d-flex">
                 <select
                   id="option-race"
                   class="form-control mr-3"
-                  style="width: 100px;"
+                  style="width: 100px"
                 >
                   <option value="random">Random</option>
                   <option value="asian">Asian</option>
@@ -109,7 +107,7 @@
                 <select
                   id="option-gender"
                   class="form-control mr-3"
-                  style="width: 80px;"
+                  style="width: 80px"
                 >
                   <option value="male">Male</option>
                   <option value="female">Female</option>
@@ -322,6 +320,26 @@
                       type="number"
                       class="form-control"
                       id="fatness"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                    />
+                  </div>
+                  <div class="group-item-multiline">
+                    <div class="group-item-header">
+                      <label for="lineOpacity">Line Visibility</label>
+                      <input
+                        class="random-attribute randomize-head"
+                        type="checkbox"
+                        value=""
+                        checked
+                        id="randomize-lineOpacity"
+                      />
+                    </div>
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="lineOpacity"
                       min="0"
                       max="1"
                       step="0.01"
@@ -650,6 +668,26 @@
                         id="randomize-mouth-flip"
                       />
                     </div>
+                  </div>
+                  <div class="group-item-multiline">
+                    <div class="group-item-header">
+                      <label for="mouth-size">Size</label>
+                      <input
+                        class="random-attribute randomize-mouth"
+                        type="checkbox"
+                        value=""
+                        checked
+                        id="randomize-mouth-size"
+                      />
+                    </div>
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="mouth-size"
+                      min="0.7"
+                      max="1.3"
+                      step="0.01"
+                    />
                   </div>
                 </div>
               </div>

--- a/src/display.ts
+++ b/src/display.ts
@@ -96,9 +96,10 @@ const translate = (
 const fatScale = (fatness: number) => 0.8 + 0.2 * fatness;
 
 type FeatureInfo = {
-  name: Exclude<keyof Face, "fatness" | "teamColors">;
+  name: Exclude<keyof Face, "fatness" | "teamColors" | "lineOpacity">;
   positions: [null] | [number, number][];
   scaleFatness?: true;
+  opaqueLines?: true;
 };
 
 const drawFeature = (svg: SVGSVGElement, face: Face, info: FeatureInfo) => {
@@ -232,6 +233,11 @@ const drawFeature = (svg: SVGSVGElement, face: Face, info: FeatureInfo) => {
       scaleCentered(svg.lastChild, scale, scale);
     }
 
+    if (info.opaqueLines) {
+      // @ts-ignore
+      svg.lastChild.setAttribute("stroke-opacity", String(face.lineOpacity));
+    }
+
     if (info.scaleFatness && info.positions[0] !== null) {
       // Scale individual feature relative to the edge of the head. If fatness is 1, then there are 47 pixels on each side. If fatness is 0, then there are 78 pixels on each side.
       const distance = (78 - 47) * (1 - face.fatness);
@@ -307,6 +313,7 @@ export const display = (
     {
       name: "eyeLine",
       positions: [null],
+      opaqueLines: true,
     },
     {
       name: "smileLine",
@@ -314,10 +321,12 @@ export const display = (
         [150, 435],
         [250, 435],
       ],
+      opaqueLines: true,
     },
     {
       name: "miscLine",
       positions: [null],
+      opaqueLines: true,
     },
     {
       name: "facialHair",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -107,6 +107,7 @@ export const generate = (
 
   const face = {
     fatness: roundTwoDecimals((gender === "female" ? 0.4 : 1) * Math.random()),
+    lineOpacity: roundTwoDecimals((0.25 + 0.5 * Math.random()) ** 2),
     teamColors: defaultTeamColors,
     hairBg: {
       id:
@@ -165,6 +166,7 @@ export const generate = (
     mouth: {
       id: getID("mouth", gender),
       flip: isFlipped,
+      size: roundTwoDecimals(0.6 + Math.random() * 0.6),
     },
     nose: {
       id: getID("nose", gender),


### PR DESCRIPTION
This PR makes two small-ish changes. **This will lead to greater variability in player faces**

**Line Opacity**:
- This attribute is "face-wide", similar to fatness, and will apply to multiple features, including miscLines, mouthLines, eyeLines
- This attribute is applied as opacity to the three features mentioned
- The attribute is generated as random() ** 2 - meaning 0.9 ➡️ 0.81, 0.5 ➡️ 0.25, 0.1 ➡️ 0.01, and so on
- The squared random function results in a phased-in line opacity, so most lines will not be 100% opaque
![image](https://github.com/tomkennedy22/facesjs/assets/5054058/805e746d-8827-4440-a144-0c95664f015c)

-----------
**Mouth Sizing**
- This attribute exists within *mouth*, and scales from 0.7 ➡️ 1.3

![image](https://github.com/tomkennedy22/facesjs/assets/5054058/5afb7437-f623-4a02-b75e-e55a9219d86e)


--------
**Request for feedback**
- Should line opacity influence whether lines appear at all? Should lines always be popualted, but not show up unless opacity > X?
- Could line opacity lead to additional aging functionality? https://github.com/zengm-games/facesjs/issues/3
- Is mouth range ok?
- Should mouth range "anchor" or have normal curve closed to 1?
